### PR TITLE
Added MACS2 to cannoli

### DIFF
--- a/cli/src/main/scala/org/bdgenomics/cannoli/cli/Cannoli.scala
+++ b/cli/src/main/scala/org/bdgenomics/cannoli/cli/Cannoli.scala
@@ -33,6 +33,7 @@ object Cannoli {
     Bowtie2,
     Bwa,
     Freebayes,
+    MACS2,                                                           
     SnpEff)),
     CommandGroup("CANNOLI TOOLS", List(InterleaveFastq,
       SampleReads)))

--- a/cli/src/main/scala/org/bdgenomics/cannoli/cli/MACS2.scala
+++ b/cli/src/main/scala/org/bdgenomics/cannoli/cli/MACS2.scala
@@ -1,0 +1,102 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.cannoli.cli
+
+import htsjdk.samtools.ValidationStringency
+import org.bdgenomics.adam.rdd.read.{ AlignmentRecordRDD, BAMInFormatter, SAMInFormatter, AnySAMInFormatter }
+import org.apache.spark.SparkContext
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.ADAMSaveAnyArgs
+import org.bdgenomics.adam.rdd.feature.{ BEDInFormatter, BEDOutFormatter, FeatureRDD }
+import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
+import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
+import org.apache.spark.rdd.RDD
+import org.apache.spark.HashPartitioner
+import org.bdgenomics.adam.models._
+import org.bdgenomics.formats.avro.Feature
+import org.bdgenomics.formats.avro.{ Feature, AlignmentRecord }
+import org.bdgenomics.adam.rdd.read.{ AlignmentRecordRDD, AnySAMOutFormatter }
+import org.bdgenomics.adam.rdd.read.{ AlignmentRecordRDD, BAMInFormatter }
+
+object MACS2 extends BDGCommandCompanion {
+  val commandName = "macs2"
+  val commandDescription = "ADAM Pipe API wrapper for MACS2."
+
+  def apply(cmdLine: Array[String]) = {
+    new MACS2(Args4j[MACS2Args](cmdLine))
+  }
+}
+
+class MACS2Args extends Args4jBase with ADAMSaveAnyArgs with ParquetArgs {
+  @Argument(required = true, metaVar = "function", usage = "MACS2 function to perform. Only callpeak is currently supported.", index = 0)
+  var function: String = null
+
+  @Argument(required = true, metaVar = "INPUT", usage = "Location to pipe from.", index = 1)
+  var inputPath: String = null
+
+  @Argument(required = true, metaVar = "OUTPUT", usage = "Location to pipe to.", index = 2)
+  var outputPath: String = null
+
+  @Args4jOption(required = true, name = "-macs2_output", usage = "Folder in which MACS2 output is saved.")
+  var macs2OutputPath: String = null
+
+  @Args4jOption(required = false, name = "-single", usage = "Saves OUTPUT as single file.")
+  var asSingleFile: Boolean = false
+
+  @Args4jOption(required = false, name = "-defer_merging", usage = "Defers merging single file output.")
+  var deferMerging: Boolean = false
+
+  @Args4jOption(required = false, name = "-disable_fast_concat", usage = "Disables the parallel file concatenation engine.")
+  var disableFastConcat: Boolean = false
+
+  @Args4jOption(required = false, name = "-stringency", usage = "Stringency level for various checks; can be SILENT, LENIENT, or STRICT. Defaults to STRICT.")
+  var stringency: String = "STRICT"
+
+  // must be defined due to ADAMSaveAnyArgs, but unused here
+  var sortFastqOutput: Boolean = false
+}
+
+/**
+ * MACS2.
+ */
+class MACS2(protected val args: MACS2Args) extends BDGSparkCommand[MACS2Args] with Logging {
+  val companion = MACS2
+  val stringency = ValidationStringency.valueOf(args.stringency)
+
+  def run(sc: SparkContext) {
+    val MACS2Command = "/home/eecs/gunjan/cannoli/run-macs2.sh " + args.macs2OutputPath
+    val inputFiles = args.inputPath.split(",")
+    val input = sc.parallelize(inputFiles, inputFiles.length)
+    val outputFiles = input.pipe(MACS2Command)
+
+    var output: FeatureRDD = null
+    for (file <- outputFiles.collect()) {
+      val features = sc.loadFeatures(file)
+      output = if (output != null) {
+        features.union(output)
+      } else {
+        features
+      }
+    }
+
+    output.save(args.outputPath,
+      asSingleFile = args.asSingleFile,
+      disableFastConcat = args.disableFastConcat)
+  }
+}

--- a/run-macs2.sh
+++ b/run-macs2.sh
@@ -1,17 +1,20 @@
+
+
 #!/bin/bash
 
 set +x
 
-# save full filepath that is piped in
-filePath=`cat`
-# save just the filename
-fileName=`basename ${filePath}`
-# save location where all MACS2 output will be saved
-outputPath=$1
+tee datafile > /dev/null
+rm -r -f NA_summits.bed
+/home/eecs/gunjan/envs/gunjan/bin/macs2 callpeak -t datafile --verbose 0
+#fileName=HELLO
+#awk -v file="$fileName" 'BEGIN{OFS="\t"}{$4=file}1' NA_summits.bed
+cat NA_summits.bed
 
-# run macs2 callpeak function
-# -t is input file, -n is prefix for output filenames, --outdir is location where files saved
-macs2 callpeak -t ${filePath} -n ${fileName} --outdir ${outputPath}/${fileName}_output
+#tee hi.txt > /dev/null
+#cp /home/eecs/gunjan/all-adam/cannoli/test.bed gunjan.bed
+#cat gunjan.bed
+#/home/eecs/gunjan/envs/gunjan/bin/macs2 callpeak -t test.bed -n HI
 
-# pipe out BED file entries from MACS2 output file
-echo ${outputPath}/${fileName}_output/${fileName}_summits.bed
+#cat /home/eecs/gunjan/all-adam/cannoli/test.bed
+#cat HI_summits.bed

--- a/run-macs2.sh
+++ b/run-macs2.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set +x
+
+# save full filepath that is piped in
+filePath=`cat`
+# save just the filename
+fileName=`basename ${filePath}`
+# save location where all MACS2 output will be saved
+outputPath=$1
+
+# run macs2 callpeak function
+# -t is input file, -n is prefix for output filenames, --outdir is location where files saved
+macs2 callpeak -t ${filePath} -n ${fileName} --outdir ${outputPath}/${fileName}_output
+
+# pipe out BED file entries from MACS2 output file
+echo ${outputPath}/${fileName}_output/${fileName}_summits.bed


### PR DESCRIPTION
Example use:
```
./bin/cannoli-submit macs2 callpeak \
    /home/eecs/gunjan/data1.bam,/home/eecs/gunjan/data2.bam \
    file:/home/eecs/gunjan/output.bed \
    -macs2_output /home/eecs/gunjan/macs2output
```
This command would create:
* For each input data file, a directory in `/home/eecs/gunjan/macs2output`. Each directory would contain four MACS2 output files (`NAME_peaks.xls`, `NAME_peaks.narrowPeak`, `NAME_summits.bed`, `NAME_model.r`).
* One combined BED file at `file:/home/eecs/gunjan/output.bed`. This file would contain data from all `NAME_summits.bed` files.

Questions/concerns:
* Where should `run-macs2.sh` be located in the repo? 
* Currently, location of `run-macs2.sh` is [hardcoded](https://github.com/gunjanbaid/cannoli/blob/d817935f31bb3a4d0fa53a0a9807c15572869bb7/cli/src/main/scala/org/bdgenomics/cannoli/cli/MACS2.scala#L83). What is the preferred method for referencing the script? I tried using `sc.addFile()` but was not clear on how to specify a relative path.
* `INPUT` and `-macs2_output` cannot be HDFS paths, `run-macs2.sh` will not be able to read from/write to HDFS locations with given script. 
* Currently saving the MACS2 output files. I can delete them if that is preferred.