### PR TITLE
Use build-helper-maven-plugin for build timestamp

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -11,10 +11,6 @@
   <artifactId>cannoli-cli-spark2_2.11</artifactId>
   <packaging>jar</packaging>
   <name>Cannoli_${scala.version.prefix}: CLI</name>
-  <properties>
-    <timestamp>${maven.build.timestamp}</timestamp>
-    <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-  </properties>
   <build>
     <plugins>
       <plugin>
@@ -37,6 +33,23 @@
             <goals>
               <goal>revision</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>timestamp-property</id>
+            <goals>
+              <goal>timestamp-property</goal>
+            </goals>
+            <configuration>
+              <name>build-helper-maven-plugin.build.timestamp</name>
+              <pattern>yyyy-MM-dd</pattern>
+              <locale>en_US</locale>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/cli/src/main/java-templates/org/bdgenomics/cannoli/cli/About.java
+++ b/cli/src/main/java-templates/org/bdgenomics/cannoli/cli/About.java
@@ -22,7 +22,7 @@ package org.bdgenomics.cannoli.cli;
  */
 public final class About {
     private static final String ARTIFACT_ID = "${project.artifactId}";
-    private static final String BUILD_TIMESTAMP = "${timestamp}";
+    private static final String BUILD_TIMESTAMP = "${build-helper-maven-plugin.build.timestamp}";
     private static final String COMMIT = "${git.commit.id}";
     private static final String ADAM_VERSION = "${adam.version}";
     private static final String SCALA_VERSION = "${scala.version}";

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>1.12</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Removes the hack necessary to work around issues with `maven.build.timestamp` property.