### PR TITLE
[CANNOLI-154] Add additional arguments to Minimap2

### DIFF
--- a/core/src/main/scala/org/bdgenomics/cannoli/Minimap2.scala
+++ b/core/src/main/scala/org/bdgenomics/cannoli/Minimap2.scala
@@ -36,8 +36,8 @@ class Minimap2Args extends Args4jBase {
   @Args4jOption(required = false, name = "-executable", usage = "Path to the Minimap2 executable. Defaults to minimap2.")
   var executable: String = "minimap2"
 
-  @Args4jOption(required = false, name = "-image", usage = "Container image to use. Defaults to quay.io/biocontainers/minimap2:2.14--ha92aebf_0.")
-  var image: String = "quay.io/biocontainers/minimap2:2.14--ha92aebf_0"
+  @Args4jOption(required = false, name = "-image", usage = "Container image to use. Defaults to quay.io/biocontainers/minimap2:2.16--h84994c4_1.")
+  var image: String = "quay.io/biocontainers/minimap2:2.16--h84994c4_1"
 
   @Args4jOption(required = false, name = "-sudo", usage = "Run via sudo.")
   var sudo: Boolean = false
@@ -59,6 +59,9 @@ class Minimap2Args extends Args4jBase {
 
   @Args4jOption(required = false, name = "-seed", usage = "Integer seed for randomizing equally best hits. Minimap2 hashes seed and read name when choosing between equally best hits. Defaults to 42.")
   var seed: Integer = 42
+
+  @Args4jOption(required = false, name = "-minimap2_args", usage = "Additional arguments for Minimap2, must be double-quoted, e.g. -minimap2_args=\"-N 42 --splice\"")
+  var minimap2Args: String = null
 }
 
 /**
@@ -81,6 +84,10 @@ class Minimap2(
       .add(args.preset)
       .add("--seed")
       .add(args.seed.toString)
+
+    Option(args.minimap2Args).foreach(builder.add(_))
+
+    builder
       .add(if (args.addFiles) "$0" else absolute(args.indexPath))
       .add("-")
 


### PR DESCRIPTION
Fixes #154 

Usage on the command line is a bit non-standard, but I can't think of a better way to do it.  We already use `--` to delineate Spark vs Cannoli arguments and mix `-long_argument` and `--long-argument` styles.
```
$ cannoli-submit \
  minimap2 \
  -index hs38DH.fa \
  -preset map-ont \
  -minimap2_args "-N 42 --splice" \
  sample.ifq \
  sample.alignments.adam
```