### PR TITLE
Add Sambamba markdup for marking duplicate reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ CANNOLI
                  gem : Align paired-end reads in a fragment dataset with GEM-Mapper.
           magicBlast : Align paired-end reads in a fragment dataset with Magic-BLAST.
             minimap2 : Align paired-end reads in a fragment dataset with Minimap2.
+     sambambaMarkdup : Mark duplicate alignments in an alignment dataset with Sambamba markdup.
      samtoolsMpileup : Call variants from an alignment dataset with samtools mpileup.
                 snap : Align paired-end reads in a fragment dataset with SNAP.
               snpEff : Annotate variant contexts with SnpEff.

--- a/cli/src/main/scala/org/bdgenomics/cannoli/cli/Cannoli.scala
+++ b/cli/src/main/scala/org/bdgenomics/cannoli/cli/Cannoli.scala
@@ -42,6 +42,7 @@ object Cannoli {
     Gem,
     MagicBlast,
     Minimap2,
+    SambambaMarkdup,
     SamtoolsMpileup,
     Snap,
     SnpEff,

--- a/cli/src/main/scala/org/bdgenomics/cannoli/cli/SambambaMarkdup.scala
+++ b/cli/src/main/scala/org/bdgenomics/cannoli/cli/SambambaMarkdup.scala
@@ -43,10 +43,10 @@ object SambambaMarkdup extends BDGCommandCompanion {
  * Sambamba markdup command line arguments.
  */
 class SambambaMarkdupArgs extends SambambaMarkdupFnArgs with ADAMSaveAnyArgs with ParquetArgs {
-  @Argument(required = true, metaVar = "INPUT", usage = "Location to pipe alignment records from (e.g. .bam, .cram, .sam). If extension is not detected, Parquet is assumed.", index = 0)
+  @Argument(required = true, metaVar = "INPUT", usage = "Location to pipe alignments from (e.g. .bam, .cram, .sam). If extension is not detected, Parquet is assumed.", index = 0)
   var inputPath: String = null
 
-  @Argument(required = true, metaVar = "OUTPUT", usage = "Location to pipe alignment records to (e.g. .bam, .cram, .sam). If extension is not detected, Parquet is assumed.", index = 1)
+  @Argument(required = true, metaVar = "OUTPUT", usage = "Location to pipe alignments to (e.g. .bam, .cram, .sam). If extension is not detected, Parquet is assumed.", index = 1)
   var outputPath: String = null
 
   @Args4jOption(required = false, name = "-single", usage = "Saves OUTPUT as single file.")

--- a/cli/src/main/scala/org/bdgenomics/cannoli/cli/SambambaMarkdup.scala
+++ b/cli/src/main/scala/org/bdgenomics/cannoli/cli/SambambaMarkdup.scala
@@ -1,0 +1,79 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.cannoli.cli
+
+import grizzled.slf4j.Logging
+import htsjdk.samtools.ValidationStringency
+import org.apache.spark.SparkContext
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.ADAMSaveAnyArgs
+import org.bdgenomics.adam.util.FileExtensions._
+import org.bdgenomics.cannoli.{
+  SambambaMarkdup => SambambaMarkdupFn,
+  SambambaMarkdupArgs => SambambaMarkdupFnArgs
+}
+import org.bdgenomics.utils.cli._
+import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
+
+object SambambaMarkdup extends BDGCommandCompanion {
+  val commandName = "sambambaMarkdup"
+  val commandDescription = "Mark duplicate alignments in an alignment dataset with Sambamba markdup."
+
+  def apply(cmdLine: Array[String]) = {
+    new SambambaMarkdup(Args4j[SambambaMarkdupArgs](cmdLine))
+  }
+}
+
+/**
+ * Sambamba markdup command line arguments.
+ */
+class SambambaMarkdupArgs extends SambambaMarkdupFnArgs with ADAMSaveAnyArgs with ParquetArgs {
+  @Argument(required = true, metaVar = "INPUT", usage = "Location to pipe alignment records from (e.g. .bam, .cram, .sam). If extension is not detected, Parquet is assumed.", index = 0)
+  var inputPath: String = null
+
+  @Argument(required = true, metaVar = "OUTPUT", usage = "Location to pipe alignment records to (e.g. .bam, .cram, .sam). If extension is not detected, Parquet is assumed.", index = 1)
+  var outputPath: String = null
+
+  @Args4jOption(required = false, name = "-single", usage = "Saves OUTPUT as single file.")
+  var asSingleFile: Boolean = false
+
+  @Args4jOption(required = false, name = "-defer_merging", usage = "Defers merging single file output.")
+  var deferMerging: Boolean = false
+
+  @Args4jOption(required = false, name = "-disable_fast_concat", usage = "Disables the parallel file concatenation engine.")
+  var disableFastConcat: Boolean = false
+
+  @Args4jOption(required = false, name = "-stringency", usage = "Stringency level for various checks; can be SILENT, LENIENT, or STRICT. Defaults to STRICT.")
+  var stringency: String = "STRICT"
+
+  // must be defined due to ADAMSaveAnyArgs, but unused here
+  var sortFastqOutput: Boolean = false
+}
+
+/**
+ * Sambamba markdup command line wrapper.
+ */
+class SambambaMarkdup(protected val args: SambambaMarkdupArgs) extends BDGSparkCommand[SambambaMarkdupArgs] with Logging {
+  val companion = SambambaMarkdup
+  val stringency: ValidationStringency = ValidationStringency.valueOf(args.stringency)
+
+  def run(sc: SparkContext) {
+    val alignments = sc.loadAlignments(args.inputPath, stringency = stringency)
+    new SambambaMarkdupFn(args, sc).apply(alignments).save(args)
+  }
+}

--- a/core/src/main/scala/org/bdgenomics/cannoli/Cannoli.scala
+++ b/core/src/main/scala/org/bdgenomics/cannoli/Cannoli.scala
@@ -92,12 +92,12 @@ object Cannoli {
     }
 
     /**
-     * Mark duplicate alignments in this AlignmentRecordDataset with sambamba markdup via Cannoli.
+     * Mark duplicate alignments in this AlignmentDataset with sambamba markdup via Cannoli.
      *
      * @param args Sambamba markdup function argments.
-     * @return AlignmentRecordDataset.
+     * @return AlignmentDataset.
      */
-    def markDuplicatesWithSambambaMarkdup(args: SambambaMarkdupArgs): AlignmentRecordDataset = {
+    def markDuplicatesWithSambambaMarkdup(args: SambambaMarkdupArgs): AlignmentDataset = {
       new SambambaMarkdup(args, alignments.rdd.context).apply(alignments)
     }
   }

--- a/core/src/main/scala/org/bdgenomics/cannoli/Cannoli.scala
+++ b/core/src/main/scala/org/bdgenomics/cannoli/Cannoli.scala
@@ -90,6 +90,16 @@ object Cannoli {
       stringency: ValidationStringency = ValidationStringency.LENIENT): VariantContextDataset = {
       new SamtoolsMpileup(args, stringency, alignments.rdd.context).apply(alignments)
     }
+
+    /**
+     * Mark duplicate alignments in this AlignmentRecordDataset with sambamba markdup via Cannoli.
+     *
+     * @param args Sambamba markdup function argments.
+     * @return AlignmentRecordDataset.
+     */
+    def markDuplicatesWithSambambaMarkdup(args: SambambaMarkdupArgs): AlignmentRecordDataset = {
+      new SambambaMarkdup(args, alignments.rdd.context).apply(alignments)
+    }
   }
 
   implicit class CannoliFeatureDataset(features: FeatureDataset) {

--- a/core/src/main/scala/org/bdgenomics/cannoli/SambambaMarkdup.scala
+++ b/core/src/main/scala/org/bdgenomics/cannoli/SambambaMarkdup.scala
@@ -34,8 +34,8 @@ class SambambaMarkdupArgs extends Args4jBase {
   @Args4jOption(required = false, name = "-executable", usage = "Path to the Sambamba executable. Defaults to sambamba.")
   var executable: String = "sambamba"
 
-  @Args4jOption(required = false, name = "-image", usage = "Container image to use. Defaults to quay.io/biocontainers/sambamba:0.7.1--h148d290_2.")
-  var image: String = "quay.io/biocontainers/sambamba:0.7.1--h148d290_2"
+  @Args4jOption(required = false, name = "-image", usage = "Container image to use. Defaults to quay.io/biocontainers/sambamba:0.7.1--h984e79f_3.")
+  var image: String = "quay.io/biocontainers/sambamba:0.7.1--h984e79f_3"
 
   @Args4jOption(required = false, name = "-remove_duplicates", usage = "Remove duplicates instead of marking them.")
   var removeDuplicates: Boolean = false

--- a/core/src/main/scala/org/bdgenomics/cannoli/SambambaMarkdup.scala
+++ b/core/src/main/scala/org/bdgenomics/cannoli/SambambaMarkdup.scala
@@ -1,0 +1,93 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.cannoli
+
+import org.apache.spark.SparkContext
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.read.{ AlignmentRecordDataset, BAMInFormatter, AnySAMOutFormatter }
+import org.bdgenomics.adam.sql.{ AlignmentRecord => AlignmentRecordProduct }
+import org.bdgenomics.cannoli.builder.CommandBuilders
+import org.bdgenomics.formats.avro.AlignmentRecord
+import org.bdgenomics.utils.cli._
+import org.kohsuke.args4j.{ Option => Args4jOption }
+import scala.collection.JavaConversions._
+
+/**
+ * Sambamba markdup function arguments.
+ */
+class SambambaMarkdupArgs extends Args4jBase {
+  @Args4jOption(required = false, name = "-executable", usage = "Path to the Sambamba executable. Defaults to sambamba.")
+  var executable: String = "sambamba"
+
+  @Args4jOption(required = false, name = "-image", usage = "Container image to use. Defaults to quay.io/biocontainers/sambamba:0.7.0--h89e63da_1.")
+  var image: String = "quay.io/biocontainers/sambamba:0.7.0--h89e63da_1"
+
+  @Args4jOption(required = false, name = "-remove_duplicates", usage = "Remove duplicates instead of marking them.")
+  var removeDuplicates: Boolean = false
+
+  @Args4jOption(required = false, name = "-sudo", usage = "Run via sudo.")
+  var sudo: Boolean = false
+
+  @Args4jOption(required = false, name = "-use_docker", usage = "If true, uses Docker to launch Sambamba markdup.")
+  var useDocker: Boolean = false
+
+  @Args4jOption(required = false, name = "-use_singularity", usage = "If true, uses Singularity to launch Sambamba markdup.")
+  var useSingularity: Boolean = false
+}
+
+/**
+ * Sambamba markdup wrapper as a function AlignmentRecordDataset &rarr; AlignmentRecordDataset,
+ * for use in cannoli-shell or notebooks.
+ *
+ * @param args Sambamba markdup function arguments.
+ * @param sc Spark context.
+ */
+class SambambaMarkdup(
+    val args: SambambaMarkdupArgs,
+    sc: SparkContext) extends CannoliFn[AlignmentRecordDataset, AlignmentRecordDataset](sc) {
+
+  override def apply(alignments: AlignmentRecordDataset): AlignmentRecordDataset = {
+
+    val builder = CommandBuilders.create(args.useDocker, args.useSingularity)
+      .setExecutable(args.executable)
+      .add("markdup")
+
+    if (args.removeDuplicates)
+      builder.add("-remove-duplicates")
+
+    builder.add("/dev/stdin")
+      .add("/dev/stdout")
+
+    if (args.useDocker || args.useSingularity) {
+      builder
+        .setImage(args.image)
+        .setSudo(args.sudo)
+    }
+
+    info("Piping %s to sambamba with command: %s files: %s".format(
+      alignments, builder.build(), builder.getFiles()))
+
+    implicit val tFormatter = BAMInFormatter
+    implicit val uFormatter = new AnySAMOutFormatter
+
+    alignments.pipe[AlignmentRecord, AlignmentRecordProduct, AlignmentRecordDataset, BAMInFormatter](
+      cmd = builder.build(),
+      files = builder.getFiles()
+    )
+  }
+}

--- a/core/src/main/scala/org/bdgenomics/cannoli/SambambaMarkdup.scala
+++ b/core/src/main/scala/org/bdgenomics/cannoli/SambambaMarkdup.scala
@@ -19,10 +19,10 @@ package org.bdgenomics.cannoli
 
 import org.apache.spark.SparkContext
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.{ AlignmentRecordDataset, BAMInFormatter, AnySAMOutFormatter }
-import org.bdgenomics.adam.sql.{ AlignmentRecord => AlignmentRecordProduct }
+import org.bdgenomics.adam.rdd.read.{ AlignmentDataset, BAMInFormatter, AnySAMOutFormatter }
+import org.bdgenomics.adam.sql.{ Alignment => AlignmentProduct }
 import org.bdgenomics.cannoli.builder.CommandBuilders
-import org.bdgenomics.formats.avro.AlignmentRecord
+import org.bdgenomics.formats.avro.Alignment
 import org.bdgenomics.utils.cli._
 import org.kohsuke.args4j.{ Option => Args4jOption }
 import scala.collection.JavaConversions._
@@ -34,8 +34,8 @@ class SambambaMarkdupArgs extends Args4jBase {
   @Args4jOption(required = false, name = "-executable", usage = "Path to the Sambamba executable. Defaults to sambamba.")
   var executable: String = "sambamba"
 
-  @Args4jOption(required = false, name = "-image", usage = "Container image to use. Defaults to quay.io/biocontainers/sambamba:0.7.0--h89e63da_1.")
-  var image: String = "quay.io/biocontainers/sambamba:0.7.0--h89e63da_1"
+  @Args4jOption(required = false, name = "-image", usage = "Container image to use. Defaults to quay.io/biocontainers/sambamba:0.7.1--h148d290_0.")
+  var image: String = "quay.io/biocontainers/sambamba:0.7.1--h148d290_0"
 
   @Args4jOption(required = false, name = "-remove_duplicates", usage = "Remove duplicates instead of marking them.")
   var removeDuplicates: Boolean = false
@@ -51,7 +51,7 @@ class SambambaMarkdupArgs extends Args4jBase {
 }
 
 /**
- * Sambamba markdup wrapper as a function AlignmentRecordDataset &rarr; AlignmentRecordDataset,
+ * Sambamba markdup wrapper as a function AlignmentDataset &rarr; AlignmentDataset,
  * for use in cannoli-shell or notebooks.
  *
  * @param args Sambamba markdup function arguments.
@@ -59,9 +59,9 @@ class SambambaMarkdupArgs extends Args4jBase {
  */
 class SambambaMarkdup(
     val args: SambambaMarkdupArgs,
-    sc: SparkContext) extends CannoliFn[AlignmentRecordDataset, AlignmentRecordDataset](sc) {
+    sc: SparkContext) extends CannoliFn[AlignmentDataset, AlignmentDataset](sc) {
 
-  override def apply(alignments: AlignmentRecordDataset): AlignmentRecordDataset = {
+  override def apply(alignments: AlignmentDataset): AlignmentDataset = {
 
     val builder = CommandBuilders.create(args.useDocker, args.useSingularity)
       .setExecutable(args.executable)
@@ -85,7 +85,7 @@ class SambambaMarkdup(
     implicit val tFormatter = BAMInFormatter
     implicit val uFormatter = new AnySAMOutFormatter
 
-    alignments.pipe[AlignmentRecord, AlignmentRecordProduct, AlignmentRecordDataset, BAMInFormatter](
+    alignments.pipe[Alignment, AlignmentProduct, AlignmentDataset, BAMInFormatter](
       cmd = builder.build(),
       files = builder.getFiles()
     )

--- a/core/src/main/scala/org/bdgenomics/cannoli/SambambaMarkdup.scala
+++ b/core/src/main/scala/org/bdgenomics/cannoli/SambambaMarkdup.scala
@@ -34,8 +34,8 @@ class SambambaMarkdupArgs extends Args4jBase {
   @Args4jOption(required = false, name = "-executable", usage = "Path to the Sambamba executable. Defaults to sambamba.")
   var executable: String = "sambamba"
 
-  @Args4jOption(required = false, name = "-image", usage = "Container image to use. Defaults to quay.io/biocontainers/sambamba:0.7.1--h148d290_0.")
-  var image: String = "quay.io/biocontainers/sambamba:0.7.1--h148d290_0"
+  @Args4jOption(required = false, name = "-image", usage = "Container image to use. Defaults to quay.io/biocontainers/sambamba:0.7.1--h148d290_2.")
+  var image: String = "quay.io/biocontainers/sambamba:0.7.1--h148d290_2"
 
   @Args4jOption(required = false, name = "-remove_duplicates", usage = "Remove duplicates instead of marking them.")
   var removeDuplicates: Boolean = false


### PR DESCRIPTION
Work in progress, not working
```
$ ./bin/cannoli-submit sambambaMarkdup \
  NA12878.alignedHg38.duplicateMarked.baseRealigned.bam \
  NA12878.alignedHg38.duplicateMarked.baseRealigned.markdup.alignments.adam

...
19/10/04 11:45:49 INFO SambambaMarkdup: Piping RDDBoundAlignmentRecordDataset
with 3366 reference sequences, 3 read groups, and 3 processing steps to sambamba
with command: [sambamba, markdup, /dev/stdin, /dev/stdout] files: []
...
19/10/04 11:46:19 INFO ShuffleBlockFetcherIterator: Started 0 remote fetches in 0 ms

sambamba 0.6.8 by Artem Tarasov and Pjotr Prins (C) 2012-2018
    LDC 1.11.0 / DMD v2.081.2 / LLVM6.0.1 / bootstrap LDC - the LLVM D compiler (0.17.6)

finding positions of the duplicate reads in the file...
  sorted 0 end pairs
     and 0 single ends (among them 0 unmatched pairs)
  collecting indices of duplicate reads...   done in 0 ms
  found 0 duplicates
collected list of positions in 0 min 0 sec
sambamba-markdup: not enough data in stream
```

Similar issues when calling directly
```
$ cat NA12878.alignedHg38.duplicateMarked.baseRealigned.bam \
  | sambamba markdup /dev/stdin /dev/stdout \
  > NA12878.alignedHg38.duplicateMarked.baseRealigned.markdup.bam

sambamba 0.6.8 by Artem Tarasov and Pjotr Prins (C) 2012-2018
    LDC 1.11.0 / DMD v2.081.2 / LLVM6.0.1 / bootstrap LDC - the LLVM D compiler (0.17.6)

finding positions of the duplicate reads in the file...
  sorted 29356 end pairs
     and 423 single ends (among them 0 unmatched pairs)
  collecting indices of duplicate reads...   done in 5 ms
  found 48 duplicates
collected list of positions in 0 min 0 sec
sambamba-markdup: not enough data in stream
```

Seems to work ok without `/dev/stdin` and `/dev/stdout`
```
$ sambamba markdup \
  NA12878.alignedHg38.duplicateMarked.baseRealigned.bam \
  NA12878.alignedHg38.duplicateMarked.baseRealigned.markdup.bam

sambamba 0.6.8 by Artem Tarasov and Pjotr Prins (C) 2012-2018
    LDC 1.11.0 / DMD v2.081.2 / LLVM6.0.1 / bootstrap LDC - the LLVM D compiler (0.17.6)

finding positions of the duplicate reads in the file...
  sorted 29356 end pairs
     and 423 single ends (among them 0 unmatched pairs)
  collecting indices of duplicate reads...   done in 4 ms
  found 48 duplicates
collected list of positions in 0 min 0 sec
marking duplicates...
collected list of positions in 0 min 2 sec
```